### PR TITLE
Fixed css classes for latest bootstrap

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,19 +38,19 @@ Then in a view you may output the notifications based on your templating engine:
 Which outputs HTML as shown below:
 
     <div id="messages">
-        <div class="alert-message error" data-alert="alert">
+        <div class="alert alert-error" data-alert="alert">
             <a class="close" href="#">×</a>
             <p>This is an error.</p>
         </div>
-        <div class="alert-message info" data-alert="alert">
+        <div class="alert alert-info" data-alert="alert">
             <a class="close" href="#">×</a>
             <p>This is an info.</p>
         </div>
-        <div class="alert-message warning" data-alert="alert">
+        <div class="alert alert-warning" data-alert="alert">
             <a class="close" href="#">×</a>
             <p>This is a warning.</p>
         </div>
-        <div class="alert-message success" data-alert="alert">
+        <div class="alert alert-success" data-alert="alert">
             <a class="close" href="#">×</a>
             <p>This is success.</p>
         </div>

--- a/index.coffee
+++ b/index.coffee
@@ -16,7 +16,7 @@ module.exports = (req, res) ->
 
             if msgs?
                 # Maintain " (double quotes) for attributes so that user can inject ' (single quotes)
-                buf.push("<div class=\"alert #{type}\" data-alert=\"alert\">")
+                buf.push("<div class=\"alert alert-#{type}\" data-alert=\"alert\">")
                 buf.push("<a class=\"close\" href=\"#\">×</a>")
                 for j in [0...msgs.length]
                     msg = msgs[j]

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = function(req, res) {
       type = types[i];
       msgs = messages[type];
       if (msgs != null) {
-        buf.push("<div class=\"alert " + type + "\" data-alert=\"alert\">");
+        buf.push("<div class=\"alert alert-" + type + "\" data-alert=\"alert\">");
         buf.push("<a class=\"close\" href=\"#\">×</a>");
         for (j = 0, _ref = msgs.length; 0 <= _ref ? j < _ref : j > _ref; 0 <= _ref ? j++ : j--) {
           msg = msgs[j];


### PR DESCRIPTION
According to the bootstrap documentation the classes used for alerts should be alert and alert-type.

http://twitter.github.com/bootstrap/components.html#alerts
